### PR TITLE
compatibility with Agile Data model

### DIFF
--- a/src/GroupModel.php
+++ b/src/GroupModel.php
@@ -76,7 +76,7 @@ class GroupModel extends \atk4\data\Model {
 
     function addField($f, $defaults = [])
     {
-        //var_dump($this->master_model->getElement($f));
+        $defaults[0] = $f;
         return $this->add($this->master_model->getElement($f), $defaults);
     }
 


### PR DESCRIPTION
to get rid of
```
Declaration of atk4\report\GroupModel::addField($f) should be compatible with atk4\data\Model::addField($name, $defaults = Array)
```
notices