### PR TITLE
Try to fix for atk4/data 1.4.1

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,120 @@
+version: "2"
+plugins:
+  # Disabling plugins until there is a reasonable way to sanitize their output
+  phpcodesniffer:
+    enabled: false
+    config:
+      standard: "PSR1,PSR2"
+      ignore_warnings: true
+      encoding: utf-8
+  phpmd:
+    enabled: false
+  sonar-php:
+    enabled: false
+
+checks:
+  argument-count:
+    config:
+      threshold: 4
+  complex-logic:
+    config:
+      threshold: 4
+  file-lines:
+    config:
+      threshold: 1000
+  method-complexity:
+    config:
+      threshold: 50
+  method-count:
+    config:
+      threshold: 40
+  method-lines:
+    config:
+      threshold: 100
+  nested-control-flow:
+    config:
+      threshold: 4
+  return-statements:
+    config:
+      threshold: 10
+  similar-code:
+    config:
+      threshold: 100
+  identical-code:
+    config:
+      threshold: 150
+
+
+#engines:
+#  duplication:
+#    enabled: true
+#    config:
+#      languages:
+#        php:
+#          mass_threshold: 50
+#  fixme:
+#    enabled: true
+#  phpmd:
+#    enabled: true
+#    exclude_fingerprints:
+#    - 9d462b7c90c564bf28007ee399340fad # table() NPath is too complex.
+#    - 7c90035f65bb3bdbd2c03c648a705aac # we use static for factory, so it's good
+#    - 80ef7f404dd4f054ca51d9ee12d9e9dd # we exit from toStrign() because it can't throw exceptions
+#    - ae61f5e0cda0328c140f3b7298dbb8af # don't complain about call to static connection, as it's a fallback
+#    - e71149b967391adfaf3347a53d3c0023 # don't complain about $junk used in foreach when we only need keys
+#    checks:
+#      CyclomaticComplexity:            # because we solve complex stuff
+#        enabled: false
+#      Naming/LongVariable:             # because we have variable naming patterns
+#        enabled: false
+#      UnusedFormalParameter:           # because when we extend methods/hooks we wish to keep unified method call interface
+#        enabled: false
+#      Design/TooManyPublicMethods:     # because we follow our internal design patters
+#        enabled: false
+#      Design/TooManyMethods:           # because we solve complex stuff
+#        enabled: false
+#      Design/LongMethod:               # because methods are as long as we need them to be
+#        enabled: false
+#      ExcessivePublicCount:            # because Model has too many public methods
+#        enabled: false
+#      Design/TooManyFields:            # because we solve complex things
+#        enabled: false
+#      Design/NpathComplexity:          # because splitting up complex stuff into methods makes things even more complex
+#        enabled: false
+#      Design/WeightedMethodCount:      # because we we solve complex stuff
+#        enabled: false
+#      Design/LongClass:                # because we design carefully what is native and what is extension
+#        enabled: false
+#      Controversial/CamelCaseMethodName:    # because we need certain method naming patterns, render_blah for rendering [blah]
+#        enabled: false
+#      Controversial/CamelCaseParameterName: #
+#        enabled: false
+#      Controversial/CamelCasePropertyName:  # because we use _better_dont_change properties
+#        enabled: false
+#      Controversial/CamelCaseVariableName:  #
+#        enabled: false
+#      Controversial/CamelCaseClassName:     # Because we use Join_SQL where we specifically include _
+#        enabled: false
+#      Naming/ShortVariable:             # because sometimes variables should be short
+#        enabled: false
+#      CleanCode/ElseExpression:         # because following this makes code more complex
+#        enabled: false
+#
+#  radon:
+#    enabled: true
+#ratings:
+#  paths:
+#  - "src/**"
+#exclude_paths:
+#- "docs/**"
+#- "tests/**"
+#- "vendor/**"
+## exclude obsolete classes
+#- "src/Field_Many.php"
+#- "src/Field_One.php"
+#- "src/Field_SQL_One.php"
+#- "src/Relation_Many.php"
+#- "src/Relation_One.php"
+#- "src/Relation_SQL_One.php"
+## exclude classes completely inherited from other repos
+#- "src/Exception.php"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ docs/build
 /build
 /vendor
 .DS_Store
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,52 @@
+language: php
+
+php:
+  - '7.2'
+  - '7.3'
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+sudo: required
+services:
+  - mysql
+
+before_script:
+  - composer self-update
+  - composer install --no-ansi
+  - mysql -e 'CREATE DATABASE report_test;'
+  - mysql -e 'SET GLOBAL max_connections = 1000;'
+  - mkdir -p build/logs
+
+script:
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then CM=""; NC=""; else CM=""; NC="--no-coverage"; fi
+  - $CM ./vendor/bin/phpunit --configuration phpunit.xml $NC
+  - $CM ./vendor/bin/phpunit --configuration phpunit-mysql.xml $NC
+
+after_script:
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then
+    echo "Merging coverage reports:";
+    vendor/bin/phpcov merge build/logs/ --clover build/logs/cc.xml;
+    echo "We now have these coverage files:";
+    ls -l build/logs;
+    echo "Sending codeclimate report:";
+    vendor/bin/test-reporter --coverage-report build/logs/cc.xml;
+    echo "Sending codecov report:";
+    TRAVIS_CMD="" bash <(curl -s https://codecov.io/bash) -f build/logs/cc.xml;
+    fi
+
+notifications:
+  slack:
+    rooms:
+      - agiletoolkit:bjrKuPBf1h4cYiNxPBQ1kF6c#dsql
+    on_success: change
+
+  urls:
+    - https://webhooks.gitter.im/e/b33a2db0c636f34bafa9
+
+  on_success: change  # options: [always|never|change] default: always
+  on_failure: always  # options: [always|never|change] default: always
+  on_start: never     # options: [always|never|change] default: always
+
+  email: false

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Agile Data - Report Extension",
     "keywords": ["agile", "data", "framework", "report", "group", "aggregation", "crud"],
     "homepage": "http://agiletoolkit.org/data/extension/report",
-    "license": "Commercial",
+    "license": "MIT",
     "authors": [
         {
             "name": "Romans Malinovskis",
@@ -13,9 +13,9 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
-        "atk4/data": "^1.1",
-        "atk4/schema": "^1.0"
+        "php": ">=7.2.0",
+        "atk4/schema": "^1.1.6",
+        "atk4/data": "^1.4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "<6",

--- a/phpunit-mysql.xml
+++ b/phpunit-mysql.xml
@@ -1,9 +1,9 @@
 <phpunit colors="true" bootstrap="vendor/autoload.php" printerClass="atk4\core\PHPUnit_AgileResultPrinter">
     <php>
-        <var name="DB_DSN" value="sqlite::memory:" />
+        <var name="DB_DSN" value="mysql:dbname=report_test;host=localhost" />
         <var name="DB_USER" value="travis" />
         <var name="DB_PASSWD" value="" />
-        <var name="DB_DBNAME" value="dsql_test" />
+        <var name="DB_DBNAME" value="report_test" />
     </php>
     <filter>
         <blacklist>
@@ -19,6 +19,6 @@
         </testsuite>
     </testsuites>
     <logging>
-        <log type="coverage-php" target="build/logs/clover.cov"/>
+        <log type="coverage-php" target="build/logs/clover-mysql.cov"/>
     </logging>
 </phpunit>

--- a/src/GroupModel.php
+++ b/src/GroupModel.php
@@ -3,6 +3,14 @@
 
 namespace atk4\report;
 
+use atk4\data\Field;
+use atk4\data\Field_SQL_Expression;
+use atk4\data\Model;
+use atk4\data\Reference;
+use atk4\dsql\Expression;
+use atk4\dsql\Expression_MySQL;
+use atk4\dsql\Query;
+
 /**
  * GroupModel allows you to query using "group by" clause on your existing model.
  * It's quite simple to set up:
@@ -25,7 +33,7 @@ namespace atk4\report;
  * The base model must not be UnionModel or another GroupModel, however it's possible to use GroupModel as nestedModel inside UnionModel.
  * UnionModel implements identical grouping rule on its own.
  */
-class GroupModel extends \atk4\data\Model
+class GroupModel extends Model
 {
     /**
      * GroupModel should always be read-only.
@@ -34,7 +42,7 @@ class GroupModel extends \atk4\data\Model
      */
     public $read_only = true;
 
-    /** @var \atk4\data\Model */
+    /** @var Model */
     public $master_model = null;
 
     /** @var string */
@@ -52,18 +60,18 @@ class GroupModel extends \atk4\data\Model
     /**
      * Constructor.
      *
-     * @param \atk4\data\Model $model
+     * @param Model $model
      * @param array            $defaults
      *
      * @return GroupModel
      */
-    public function __construct(\atk4\data\Model $model, $defaults = [])
+    public function __construct(Model $model, $defaults = [])
     {
         $this->master_model = $model;
         $this->table = $model->table;
 
         //$this->_default_class_addExpression = $model->_default_class_addExpression;
-        return parent::__construct($model->persistence, $defaults);
+        parent::__construct($model->persistence, $defaults);
     }
 
     /**
@@ -106,7 +114,7 @@ class GroupModel extends \atk4\data\Model
      *
      * @return Field
      */
-    public function getRef($link) : \atk4\data\Reference
+    public function getRef($link) : Reference
     {
         return $this->master_model->getRef($link);
     }
@@ -132,10 +140,10 @@ class GroupModel extends \atk4\data\Model
     /**
      * Given a query, will add safe fields in.
      *
-     * @param \atk4\dsql\Query $query
+     * @param Query $query
      * @param array            $fields
      *
-     * @return \atk4\dsql\Query
+     * @return Query
      */
     public function queryFields($query, $fields = [])
     {
@@ -147,7 +155,7 @@ class GroupModel extends \atk4\data\Model
     /**
      * Adds grouping in query.
      *
-     * @param \atk4\dsql\Query $query
+     * @param Query $query
      */
     public function addGrouping($query)
     {
@@ -199,7 +207,7 @@ class GroupModel extends \atk4\data\Model
      * @param string $mode
      * @param array  $args
      *
-     * @return \atk4\dsql\Query
+     * @return Query
      */
     public function action($mode, $args = [])
     {
@@ -215,7 +223,7 @@ class GroupModel extends \atk4\data\Model
 
             // get list of available fields
             foreach ($this->elements as $key=>$f) {
-                if ($f instanceof \atk4\data\Field) {
+                if ($f instanceof Field) {
                     $fields[] = $key;
                 }
             }
@@ -228,7 +236,7 @@ class GroupModel extends \atk4\data\Model
             if ($this->getElement($field)->never_persist) {
                 continue;
             }
-            if ($this->getElement($field) instanceof \atk4\data\Expression_SQL) {
+            if ($this->getElement($field) instanceof Expression) {
                 continue;
             }
             $fields2[] = $field;
@@ -265,7 +273,7 @@ class GroupModel extends \atk4\data\Model
 
             case 'field':
                 if (!is_string($args[0])) {
-                    throw new Exception(['action(field) only support string fields', 'field'=>$arg[0]]);
+                    throw new Exception(['action(field) only support string fields', 'field'=>$args[0]]);
                 }
 
                 $subquery = $this->getSubQuery([$args[0]]);
@@ -273,7 +281,7 @@ class GroupModel extends \atk4\data\Model
                 if (!isset($args[0])) {
                     throw new Exception([
                         'This action requires one argument with field name',
-                        'action' => $type,
+                        'action' => $mode,
                     ]);
                 }
                 break;
@@ -339,14 +347,14 @@ class GroupModel extends \atk4\data\Model
             }
 
             if (count($cond) == 2) {
-                if ($cond[0] instanceof \atk4\data\Field) {
+                if ($cond[0] instanceof Field) {
                     $cond[1] = $this->persistence->typecastSaveField($cond[0], $cond[1]);
                     $q->having($cond[0]->actual ?: $cond[0]->short_name, $cond[1]);
                 } else {
                     $q->where($cond[0], $cond[1]);
                 }
             } else {
-                if ($cond[0] instanceof \atk4\data\Field) {
+                if ($cond[0] instanceof Field) {
                     $cond[2] = $this->persistence->typecastSaveField($cond[0], $cond[2]);
                     $q->having($cond[0]->actual ?: $cond[0]->short_name, $cond[1], $cond[2]);
                 } else {

--- a/tests/Client.php
+++ b/tests/Client.php
@@ -2,7 +2,9 @@
 
 namespace atk4\report\tests;
 
-class Client extends \atk4\data\Model 
+use atk4\data\Model;
+
+class Client extends Model
 {
     public $table = 'client';
 

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -3,10 +3,13 @@
 namespace atk4\report\tests;
 
 
+use atk4\report\GroupModel;
+use atk4\schema\PHPUnit_SchemaTestCase;
+
 /**
  * Tests basic create, update and delete operatiotns
  */
-class GroupTest extends \atk4\schema\PHPUnit_SchemaTestCase
+class GroupTest extends PHPUnit_SchemaTestCase
 {
 
     private $init_db = 
@@ -30,9 +33,10 @@ class GroupTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
     function setUp() {
         parent::setUp();
+        $this->setDB($this->init_db);
         $m1 = new Invoice($this->db);
         $m1->getRef('client_id')->addTitle();
-        $this->g = new \atk4\report\GroupModel($m1);
+        $this->g = new GroupModel($m1);
         $this->g->addField('client');
     }
 

--- a/tests/Invoice.php
+++ b/tests/Invoice.php
@@ -1,7 +1,9 @@
 <?php
 
 namespace atk4\report\tests;
-class Invoice extends \atk4\data\Model 
+use atk4\data\Model;
+
+class Invoice extends Model
 {
     public $table = 'invoice';
 
@@ -10,6 +12,6 @@ class Invoice extends \atk4\data\Model
         $this->addField('name');
 
         $this->hasOne('client_id', new Client());
-        $this->addField('amount', ['money'=>true]);
+        $this->addField('amount', ['type'=>'money']);
     }
 }

--- a/tests/Payment.php
+++ b/tests/Payment.php
@@ -1,7 +1,9 @@
 <?php
 
 namespace atk4\report\tests;
-class Payment extends \atk4\data\Model 
+use atk4\data\Model;
+
+class Payment extends Model
 {
     public $table = 'payment';
 
@@ -10,6 +12,6 @@ class Payment extends \atk4\data\Model
         $this->addField('name');
 
         $this->hasOne('client_id', 'Client');
-        $this->addField('amount', ['money'=>true]);
+        $this->addField('amount', ['type'=>'money']);
     }
 }

--- a/tests/Report1Test.php
+++ b/tests/Report1Test.php
@@ -3,10 +3,13 @@
 namespace atk4\report\tests;
 
 
+use atk4\report\GroupModel;
+use atk4\schema\PHPUnit_SchemaTestCase;
+
 /**
  * Tests basic create, update and delete operatiotns
  */
-class Report1Test extends \atk4\schema\PHPUnit_SchemaTestCase
+class Report1Test extends PHPUnit_SchemaTestCase
 {
 
     private $init_db = 
@@ -30,9 +33,10 @@ class Report1Test extends \atk4\schema\PHPUnit_SchemaTestCase
 
     function setUp() {
         parent::setUp();
+        $this->setDB($this->init_db);
         $m1 = new Invoice($this->db);
         $m1->getRef('client_id')->addTitle();
-        $this->g = new \atk4\report\GroupModel($m1);
+        $this->g = new GroupModel($m1);
         $this->g->addField('client');
     }
 
@@ -40,7 +44,7 @@ class Report1Test extends \atk4\schema\PHPUnit_SchemaTestCase
     {
         $g = $this->g;
 
-        $g->groupBy(['clienit_id'], ['c'=>'count(*)']);
+        $g->groupBy(['client_id'], ['c'=>'count(*)']);
 
         $this->assertEquals(
             [

--- a/tests/Transaction.php
+++ b/tests/Transaction.php
@@ -1,7 +1,9 @@
 <?php
 
 namespace atk4\report\tests;
-class Transaction extends \atk4\report\UnionModel 
+use atk4\report\UnionModel;
+
+class Transaction extends UnionModel
 {
     function init() {
         parent::init();

--- a/tests/Transaction2.php
+++ b/tests/Transaction2.php
@@ -1,7 +1,9 @@
 <?php
 
 namespace atk4\report\tests;
-class Transaction2 extends \atk4\report\UnionModel 
+use atk4\report\UnionModel;
+
+class Transaction2 extends UnionModel
 {
     function init() {
         parent::init();

--- a/tests/UnionExprTest.php
+++ b/tests/UnionExprTest.php
@@ -3,10 +3,12 @@
 namespace atk4\report\tests;
 
 
+use atk4\schema\PHPUnit_SchemaTestCase;
+
 /**
  * Tests basic create, update and delete operatiotns
  */
-class UnionExprTest extends \atk4\schema\PHPUnit_SchemaTestCase
+class UnionExprTest extends PHPUnit_SchemaTestCase
 {
 
     private $init_db = 
@@ -28,6 +30,7 @@ class UnionExprTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
     function setUp() {
         parent::setUp();
+        $this->setDB($this->init_db);
         $this->t = new Transaction2($this->db);
     }
 

--- a/tests/UnionTest.php
+++ b/tests/UnionTest.php
@@ -3,10 +3,12 @@
 namespace atk4\report\tests;
 
 
+use atk4\schema\PHPUnit_SchemaTestCase;
+
 /**
  * Tests basic create, update and delete operatiotns
  */
-class UnionTest extends \atk4\schema\PHPUnit_SchemaTestCase
+class UnionTest extends PHPUnit_SchemaTestCase
 {
 
     private $init_db = 
@@ -28,6 +30,7 @@ class UnionTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
     function setUp() {
         parent::setUp();
+        $this->setDB($this->init_db);
         $this->t = new Transaction($this->db);
     }
 


### PR DESCRIPTION
I try to upgrade to 1.4.1, i arrive at a point where i get some "errors" that are related to expression quoting in atk4/dsql.

Can someone put an eye on this, i don't want to arbitrary change the test to make it pass?

```
Failed asserting that two strings are equal.
Expected :'select sum(`cnt`) from ((select count(*) `cnt` from `invoice`) UNION ALL (select count(*) `cnt` from `payment`)) `derivedTable`'
Actual   :'select sum(cnt) from ((select count(*) `cnt` from `invoice`) UNION ALL (select count(*) `cnt` from `payment`)) `derivedTable`'
<Click to see difference>

...atk4/report/tests/UnionExprTest.php:97
```